### PR TITLE
Whoops! Added missing cubing-icon class for open rounds.

### DIFF
--- a/templates/dataEntry.html
+++ b/templates/dataEntry.html
@@ -7,7 +7,7 @@
             <li class="{{#if isSelectedRound}}active{{/if}} leaf">
               <a href="{{pathFor 'dataEntry' competitionUrlId=../competitionUrlId eventCode=eventCode nthRound=nthRound}}"
                  class="brand">
-                <span class="icon-{{eventCode}}" alt="{{eventCode}}"></span>
+                <span class="cubing-icon icon-{{eventCode}}" alt="{{eventCode}}"></span>
                 {{eventName eventCode}}: {{roundName roundCode}}
               </a>
             </li>


### PR DESCRIPTION
I missed this before when switching us over to cubing/icons.