### PR TITLE
Added an optional updatedAt field to SolveTime.

### DIFF
--- a/both/_collections.js
+++ b/both/_collections.js
@@ -425,6 +425,12 @@ SolveTime = new SimpleSchema({
     min: 0,
     optional: true,
   },
+  // Note that we don't use an autovalue for this. This is because we do
+  // trust clients to send us timestamps if they want to.
+  updatedAt: {
+    type: Date,
+    optional: true
+  },
 });
 
 MIN_ROUND_DURATION_MINUTES = 30;

--- a/both/methods.js
+++ b/both/methods.js
@@ -23,6 +23,10 @@ var throwIfNotSiteAdmin = function(userId) {
 };
 
 setSolveTime = function(resultId, solveIndex, solveTime) {
+  // If the client didn't send us a timestamp, cons one up here.
+  if(!solveTime.updatedAt) {
+    solveTime.updatedAt = new Date();
+  }
   var result = Results.findOne(resultId, {
     fields: {
       competitionId: 1,


### PR DESCRIPTION
When setSolveTime is called, it will honor an updatedAt timestamp from a client, but will cons one up if
there is no updatedAt field already. I declare that this fixes #194.

If something like Wingman wants to include an updatedAt field, then we will trust it.